### PR TITLE
Save some cycle inside the planner

### DIFF
--- a/Marlin/planner.cpp
+++ b/Marlin/planner.cpp
@@ -662,7 +662,7 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
         SERIAL_ECHOLNPGM(MSG_ERR_COLD_EXTRUDE_STOP);
       }
       #if ENABLED(PREVENT_LENGTHY_EXTRUDE)
-        if (labs(de) > axis_steps_per_mm[E_AXIS] * (EXTRUDE_MAXLENGTH)) {
+        if (labs(de) > (int32_t)axis_steps_per_mm[E_AXIS] * (EXTRUDE_MAXLENGTH)) { // It's not important to get max. extrusion length in a precision < 1mm, so save some cycles and cast to int
           position[E_AXIS] = target[E_AXIS]; // Behave as if the move really took place, but ignore E part
           de = 0; // no difference
           SERIAL_ECHO_START;
@@ -699,10 +699,11 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
   #endif
   if (de < 0) SBI(dm, E_AXIS);
 
-  int32_t esteps = labs(de) * volumetric_multiplier[extruder] * flow_percentage[extruder] * 0.01 + 0.5;
+  float esteps_float = de * volumetric_multiplier[extruder] * flow_percentage[extruder] * 0.01;
+  int32_t esteps = abs(esteps_float) + 0.5;
 
   // Calculate the buffer head after we push this byte
-  int next_buffer_head = next_block_index(block_buffer_head);
+  int8_t next_buffer_head = next_block_index(block_buffer_head);
 
   // If the buffer is full: good! That means we are well ahead of the robot.
   // Rest here until there is room in the buffer.
@@ -798,7 +799,7 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
 
     #if ENABLED(DISABLE_INACTIVE_EXTRUDER) // Enable only the selected extruder
 
-      for (int i = 0; i < EXTRUDERS; i++)
+      for (int8_t i = 0; i < EXTRUDERS; i++)
         if (g_uc_extruder_last_move[i] > 0) g_uc_extruder_last_move[i]--;
 
       switch(extruder) {
@@ -903,7 +904,7 @@ void Planner::_buffer_line(const float &a, const float &b, const float &c, const
     delta_mm[Y_AXIS] = db * steps_to_mm[Y_AXIS];
     delta_mm[Z_AXIS] = dc * steps_to_mm[Z_AXIS];
   #endif
-  delta_mm[E_AXIS] = 0.01 * (de * steps_to_mm[E_AXIS]) * volumetric_multiplier[extruder] * flow_percentage[extruder];
+  delta_mm[E_AXIS] = esteps_float * steps_to_mm[E_AXIS];
 
   if (block->steps[X_AXIS] < MIN_STEPS_PER_SEGMENT && block->steps[Y_AXIS] < MIN_STEPS_PER_SEGMENT && block->steps[Z_AXIS] < MIN_STEPS_PER_SEGMENT) {
     block->millimeters = fabs(delta_mm[E_AXIS]);

--- a/Marlin/planner.h
+++ b/Marlin/planner.h
@@ -117,7 +117,7 @@ typedef struct {
            acceleration_steps_per_s2;       // acceleration steps/sec^2
 
   #if FAN_COUNT > 0
-    uint32_t fan_speed[FAN_COUNT];
+    uint16_t fan_speed[FAN_COUNT];
   #endif
 
   #if ENABLED(BARICUDA)


### PR DESCRIPTION
planner.h:
fan speed is used to set integer variables, so no need for long.
Basicaly a byte should be enough for all the fan things, as it's 0-255?

planner.cpp:
Save some float multiplications.
We could squeeze out even more by defining feedrate_percentage,
saved_feedrate_percentage and flow_percentage as float instead of int.
Everytime they are used in the time-critical planner, they are casted to
float and multiplied by 0.01. Not done jet, as they are used in LCD menu
functions I don't know well enough.