### PR TITLE
Prevent re-entering of temperature ISR

### DIFF
--- a/Marlin/stepper.cpp
+++ b/Marlin/stepper.cpp
@@ -343,7 +343,7 @@ ISR(TIMER1_COMPA_vect) {
 }
 
 void Stepper::isr() {
-  #define _ENABLE_ISRs() cli(); SBI(TIMSK0, OCIE0B); ENABLE_STEPPER_DRIVER_INTERRUPT()
+  #define _ENABLE_ISRs() cli(); if (thermalManager.in_temp_isr) CBI(TIMSK0, OCIE0B); else SBI(TIMSK0, OCIE0B); ENABLE_STEPPER_DRIVER_INTERRUPT()
 
   uint16_t timer, remainder, ocr_val;
 
@@ -868,7 +868,10 @@ void Stepper::isr() {
 
     // Restore original ISR settings
     cli();
-    SBI(TIMSK0, OCIE0B);
+    if (thermalManager.in_temp_isr)
+      CBI(TIMSK0, OCIE0B);
+    else
+      SBI(TIMSK0, OCIE0B);
     ENABLE_STEPPER_DRIVER_INTERRUPT();
   }
 

--- a/Marlin/temperature.h
+++ b/Marlin/temperature.h
@@ -60,7 +60,9 @@ class Temperature {
                  target_temperature[HOTENDS],
                  current_temperature_bed_raw,
                  target_temperature_bed;
-
+    
+    static volatile bool in_temp_isr;
+    
     #if ENABLED(TEMP_SENSOR_1_AS_REDUNDANT)
       static float redundant_temperature;
     #endif


### PR DESCRIPTION
If Marlin is inside the temperature ISR, the stepper ISR is enabled. If
a stepper event is now happening Marlin will proceed with the stepper
ISR. Now, at the end of the stepper ISR, the temperatre ISR gets enabled
again. While Marlin proceed the rest of the temperature ISR, it's now
vulnerable to a second ISR call.